### PR TITLE
KFSTP-1471

### DIFF
--- a/work/src/org/kuali/kfs/module/ar/businessobject/ArGenericAttributes.java
+++ b/work/src/org/kuali/kfs/module/ar/businessobject/ArGenericAttributes.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,7 +28,6 @@ import org.kuali.rice.krad.bo.TransientBusinessObjectBase;
  */
 public class ArGenericAttributes extends TransientBusinessObjectBase {
 
-    private Long proposalNumber;
     private String agencyNumber;
     private String agencyFullName;
     private String letterOfCreditFundCode;
@@ -44,14 +43,6 @@ public class ArGenericAttributes extends TransientBusinessObjectBase {
         m.put("hashCode", Integer.toHexString(hashCode()));
 
         return m;
-    }
-
-    public Long getProposalNumber() {
-        return proposalNumber;
-    }
-
-    public void setProposalNumber(Long proposalNumber) {
-        this.proposalNumber = proposalNumber;
     }
 
     public String getAgencyNumber() {

--- a/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/ArGenericAttributes.xml
+++ b/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/ArGenericAttributes.xml
@@ -25,7 +25,6 @@
 		<property name="businessObjectClass" value="org.kuali.kfs.module.ar.businessobject.ArGenericAttributes"/>
 		<property name="attributes">
 			<list>
-				<ref bean="ArGenericAttributes-proposalNumber"/>
 				<ref bean="ArGenericAttributes-agencyNumber"/>
 				<ref bean="ArGenericAttributes-agencyFullName"/>
 				<ref bean="ArGenericAttributes-letterOfCreditFundGroupCode"/>
@@ -36,23 +35,6 @@
 	</bean>
 
   	<!-- CGB related attributes -->
-	<bean id="ArGenericAttributes-proposalNumber" parent="ArGenericAttributes-proposalNumber-parentBean" />
-
-	<bean id="ArGenericAttributes-proposalNumber-parentBean" abstract="true"
-		parent="AttributeDefinition">
-		<property name="name" value="proposalNumber" />
-		<property name="forceUppercase" value="true" />
-		<property name="label" value="Proposal Number" />
-		<property name="shortLabel" value="Number" />
-		<property name="maxLength" value="12" />
-		<property name="validationPattern">
-			<ref bean="NumericValidation" />
-		</property>
-		<property name="control">
-			<bean parent="TextControlDefinition" p:size="14" />
-		</property>
-	</bean>
-
 	<bean id="ArGenericAttributes-agencyNumber" parent="ArGenericAttributes-agencyNumber-parentBean" />
 
 	<bean id="ArGenericAttributes-agencyNumber-parentBean" abstract="true"

--- a/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/CollectionActivityInvoiceLookup.xml
+++ b/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/CollectionActivityInvoiceLookup.xml
@@ -54,7 +54,10 @@
 	<!-- Attribute Definitions -->
 
 	<bean id="CollectionActivityInvoiceLookup-proposalNumber" parent="CollectionActivityInvoiceLookup-proposalNumber-parentBean" />
-	<bean id="CollectionActivityInvoiceLookup-proposalNumber-parentBean" abstract="true" parent="ArGenericAttributes-proposalNumber" />
+	<bean id="CollectionActivityInvoiceLookup-proposalNumber-parentBean" abstract="true" parent="ExternalizableAttributeDefinitionProxy"
+		p:sourceExternalizableBusinessObjectInterface="org.kuali.kfs.integration.cg.ContractsAndGrantsAward" p:sourceAttributeName="proposalNumber">
+		<property name="name" value="proposalNumber"/>
+	</bean>
 
 	<bean id="CollectionActivityInvoiceLookup-agencyNumber" parent="CollectionActivityInvoiceLookup-agencyNumber-parentBean" />
 	<bean id="CollectionActivityInvoiceLookup-agencyNumber-parentBean" abstract="true" parent="Agency-agencyNumber" />

--- a/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/ContractsGrantsInvoiceLookupResults.xml
+++ b/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/ContractsGrantsInvoiceLookupResults.xml
@@ -65,7 +65,10 @@
 	<!-- Attribute Definitions -->
 
 	<bean id="ContractsGrantsInvoiceLookupResult-proposalNumber" parent="ContractsGrantsInvoiceLookupResult-proposalNumber-parentBean" />
-	<bean id="ContractsGrantsInvoiceLookupResult-proposalNumber-parentBean" abstract="true" parent="ArGenericAttributes-proposalNumber" />
+	<bean id="ContractsGrantsInvoiceLookupResult-proposalNumber-parentBean" abstract="true" parent="ExternalizableAttributeDefinitionProxy"
+		p:sourceExternalizableBusinessObjectInterface="org.kuali.kfs.integration.cg.ContractsAndGrantsAward" p:sourceAttributeName="proposalNumber">
+		<property name="name" value="proposalNumber"/>
+	</bean>
 
 	<bean id="ContractsGrantsInvoiceLookupResult-agencyNumber" parent="ContractsGrantsInvoiceLookupResult-agencyNumber-parentBean" />
 	<bean id="ContractsGrantsInvoiceLookupResult-agencyNumber-parentBean" abstract="true" parent="ArGenericAttributes-agencyNumber" />

--- a/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/ReferralToCollectionsDetail.xml
+++ b/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/ReferralToCollectionsDetail.xml
@@ -44,7 +44,10 @@
 	<!-- Attribute Definitions -->
 
 	<bean id="ReferralToCollectionsDetail-proposalNumber" parent="ReferralToCollectionsDetail-proposalNumber-parentBean" />
-	<bean id="ReferralToCollectionsDetail-proposalNumber-parentBean" abstract="true" parent="ArGenericAttributes-proposalNumber" />
+	<bean id="ReferralToCollectionsDetail-proposalNumber-parentBean" abstract="true" parent="ExternalizableAttributeDefinitionProxy"
+		p:sourceExternalizableBusinessObjectInterface="org.kuali.kfs.integration.cg.ContractsAndGrantsAward" p:sourceAttributeName="proposalNumber">
+		<property name="name" value="proposalNumber"/>
+	</bean>
 
 	<bean id="ReferralToCollectionsDetail-referralTypeCode" parent="ReferralToCollectionsDetail-referralTypeCode-parentBean" />
 	<bean id="ReferralToCollectionsDetail-referralTypeCode-parentBean" abstract="true" parent="AttributeDefinition">

--- a/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/ReferralToCollectionsLookupResult.xml
+++ b/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/ReferralToCollectionsLookupResult.xml
@@ -90,7 +90,10 @@
 	<!-- Attribute Definitions -->
 
 	<bean id="ReferralToCollectionsLookupResult-proposalNumber" parent="ReferralToCollectionsLookupResult-proposalNumber-parentBean" />
-	<bean id="ReferralToCollectionsLookupResult-proposalNumber-parentBean" abstract="true" parent="ArGenericAttributes-proposalNumber" />
+	<bean id="ReferralToCollectionsLookupResult-proposalNumber-parentBean" abstract="true" parent="ExternalizableAttributeDefinitionProxy"
+		p:sourceExternalizableBusinessObjectInterface="org.kuali.kfs.integration.cg.ContractsAndGrantsAward" p:sourceAttributeName="proposalNumber">
+		<property name="name" value="proposalNumber"/>
+	</bean>
 
 	<bean id="ReferralToCollectionsLookupResult-agencyNumber" parent="ReferralToCollectionsLookupResult-agencyNumber-parentBean" />
 	<bean id="ReferralToCollectionsLookupResult-agencyNumber-parentBean" abstract="true" parent="ArGenericAttributes-agencyNumber">

--- a/work/web-root/WEB-INF/tags/module/ar/collectionActivityAwardInformation.tag
+++ b/work/web-root/WEB-INF/tags/module/ar/collectionActivityAwardInformation.tag
@@ -37,6 +37,8 @@
 	value="${DataDictionary['Agency'].attributes}" />
 <c:set var="collectionEventAttributes"
 	value="${DataDictionary['CollectionEvent'].attributes}" />
+<c:set var="contractsGrantsCollectionActivityAttributes"
+	value="${DataDictionary.CollectionActivityDocument.attributes}"/>
 
 <kul:tab tabTitle="Award Information" defaultOpen="true"
 	tabErrorKey="${KFSConstants.PaymentApplicationTabErrorCodes.APPLY_TO_INVOICE_DETAIL_TAB}">
@@ -45,7 +47,7 @@
 		<table width="100%" cellpadding="0" cellspacing="0" class="datatable">
 			<tr>
 				<kul:htmlAttributeHeaderCell width="50%"
-					literalLabel="Proposal Number" horizontal="true" />
+					attributeEntry="${contractsGrantsCollectionActivityAttributes.proposalNumber}" useShortLabel="false" horizontal="true" />
 				<td>
 					<kul:htmlControlAttribute readOnly="true"
 						attributeEntry="${awardAttributes.proposalNumber}"


### PR DESCRIPTION
fix hard coding of proposal number at least in collectionActivityAwardInformation.tag; remove proposal number from ArGenericAttributes since it will always preclude KC name switching; fix places which had used ArGenericAttributes-proposalNumber so that they go to the externalizable business object implementation instead
