### PR TITLE
KFSTP-1638

### DIFF
--- a/work/src/org/kuali/kfs/module/ar/businessobject/TicklersReport.java
+++ b/work/src/org/kuali/kfs/module/ar/businessobject/TicklersReport.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,10 +23,8 @@ import java.util.LinkedHashMap;
 
 import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAgency;
 import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAward;
-import org.kuali.kfs.module.ar.ArKeyConstants;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.context.SpringContext;
-import org.kuali.rice.core.api.config.property.ConfigurationService;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.krad.bo.TransientBusinessObjectBase;
@@ -57,8 +55,6 @@ public class TicklersReport extends TransientBusinessObjectBase {
     private Person collector;
     private final String userLookupRoleNamespaceCode = KFSConstants.OptionalModuleNamespaces.ACCOUNTS_RECEIVABLE;
     private final String userLookupRoleName = KFSConstants.SysKimApiConstants.ACCOUNTS_RECEIVABLE_COLLECTOR;
-    private static final String COLLECTION_ACTIVITY_TITLE_PROPERTY = ArKeyConstants.ContractsGrantsCollectionActivityDocumentConstants.TITLE_PROPERTY;
-    private String collectionActivityInquiryTitle;
     private ContractsAndGrantsBillingAward award;
     private ContractsAndGrantsBillingAgency agency;
 
@@ -350,25 +346,6 @@ public class TicklersReport extends TransientBusinessObjectBase {
     public void setBalanceDue(KualiDecimal balanceDue) {
         this.balanceDue = balanceDue;
     }
-
-    /**
-     * Gets the collectionActivityInquiryTitle attribute.
-     *
-     * @return Returns the collectionActivityInquiryTitle.
-     */
-    public String getCollectionActivityInquiryTitle() {
-        return SpringContext.getBean(ConfigurationService.class).getPropertyValueAsString(COLLECTION_ACTIVITY_TITLE_PROPERTY);
-    }
-
-    /**
-     * Sets the collectionActivityInquiryTitle attribute value.
-     *
-     * @param collectionActivityInquiryTitle The collectionActivityInquiryTitle to set.
-     */
-    public void setCollectionActivityInquiryTitle(String collectionActivityInquiryTitle) {
-        this.collectionActivityInquiryTitle = collectionActivityInquiryTitle;
-    }
-
 
     /**
      * Gets the award attribute.

--- a/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/TicklersReport.xml
+++ b/work/src/org/kuali/kfs/module/ar/businessobject/datadictionary/TicklersReport.xml
@@ -50,7 +50,6 @@
  				<ref bean="TicklersReport-invoiceAmount" />
  				<ref bean="TicklersReport-paymentAmount" />
  				<ref bean="TicklersReport-balanceDue" />
- 				<ref bean="TicklersReport-collectionActivityInquiryTitle"/>
 			</list>
 		</property>
 		    <property name="relationships">
@@ -308,18 +307,6 @@
 		<property name="label" value="Balance Due" />
 		<property name="shortLabel" value="Balance Due" />
 	</bean>
-
-	  <bean id="TicklersReport-collectionActivityInquiryTitle" parent="TicklersReport-collectionActivityInquiryTitle-parentBean" />
-	
-	<bean id="TicklersReport-collectionActivityInquiryTitle-parentBean" abstract="true"
-		parent="AttributeDefinition">
-		<property name="name" value="collectionActivityInquiryTitle" />
-		<property name="label" value="Actions" />
-		<property name="shortLabel" value="Actions" />
-		<property name="control">
-			<bean parent="TextControlDefinition" p:size="5" />
-		</property>
-	</bean>
   
 	<!-- Business Object Lookup Definition -->
 	<bean id="TicklersReport-lookupDefinition"
@@ -360,7 +347,6 @@
 				<bean parent="FieldDefinition" p:attributeName="invoiceAmount" />
 				<bean parent="FieldDefinition" p:attributeName="paymentAmount" />
 				<bean parent="FieldDefinition" p:attributeName="balanceDue" />
-				<bean parent="FieldDefinition" p:attributeName="collectionActivityInquiryTitle"/>
 			</list>
 		</property>
 	</bean>

--- a/work/src/org/kuali/kfs/module/ar/spring-ar.xml
+++ b/work/src/org/kuali/kfs/module/ar/spring-ar.xml
@@ -965,6 +965,9 @@
 
 	<bean id="ticklersReportLookupableHelperService" class="org.kuali.kfs.module.ar.businessobject.lookup.TicklersReportLookupableHelperServiceImpl"
 		scope="prototype" parent="contractsGrantsLookupableHelperService">
+		<property name="configurationService">
+			<ref bean="configurationService"/>
+		</property>
 		<property name="contractsGrantsInvoiceDocumentService">
 			<ref bean="contractsGrantsInvoiceDocumentService" />
 		</property>

--- a/work/src/org/kuali/kfs/module/ar/web/struts/CollectionActivityReportAction.java
+++ b/work/src/org/kuali/kfs/module/ar/web/struts/CollectionActivityReportAction.java
@@ -68,9 +68,9 @@ public class CollectionActivityReportAction extends ContractsGrantsReportLookupA
     }
 
     /**
-    +     * Always returns true, as collection activity report rows always have actions
-    +     * @see org.kuali.kfs.module.ar.web.struts.ContractsGrantsReportLookupAction#shouldDisplayActionsForRow()
-    +     */
+     * Always returns true, as collection activity report rows always have actions
+     * @see org.kuali.kfs.module.ar.web.struts.ContractsGrantsReportLookupAction#shouldDisplayActionsForRow()
+     */
     @Override
     public boolean shouldDisplayActionsForRow() {
         return true;

--- a/work/src/org/kuali/kfs/module/ar/web/struts/TicklersReportLookupAction.java
+++ b/work/src/org/kuali/kfs/module/ar/web/struts/TicklersReportLookupAction.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -63,4 +63,12 @@ public class TicklersReportLookupAction extends ContractsGrantsReportLookupActio
         return TicklersReport.class;
     }
 
+    /**
+     * Always returns true, as tickler report rows always have actions
+     * @see org.kuali.kfs.module.ar.web.struts.ContractsGrantsReportLookupAction#shouldDisplayActionsForRow()
+     */
+    @Override
+    public boolean shouldDisplayActionsForRow() {
+        return true;
+    }
 }


### PR DESCRIPTION
change action urls on Tickler Report from the weird non-standard way of creating action links to instead using the getCustomActionUrls in the lookupable helper
