### PR TITLE
KFSTP-1696

### DIFF
--- a/test/unit/src/org/kuali/kfs/module/ar/document/service/ContractsGrantsInvoiceDocumentServiceTest.java
+++ b/test/unit/src/org/kuali/kfs/module/ar/document/service/ContractsGrantsInvoiceDocumentServiceTest.java
@@ -1214,12 +1214,17 @@ public class ContractsGrantsInvoiceDocumentServiceTest extends KualiTestBase {
         InvoiceGeneralDetail inv_Gnrl_Dtl_Bill = InvoiceGeneralDetailFixture.INV_GNRL_DTL4.createInvoiceGeneralDetail();
         contractsGrantsInvoiceDocument.setInvoiceGeneralDetail(inv_Gnrl_Dtl_1);
 
-        ContractsGrantsInvoiceDetail invoiceDetail_1 = ContractsGrantsInvoiceDetailFixture.INV_DTL1.createInvoiceDetail();
-        ContractsGrantsInvoiceDetail invoiceDetail_2 = ContractsGrantsInvoiceDetailFixture.INV_DTL3.createInvoiceDetail();
+        ContractsGrantsInvoiceDetail invoiceDetail_1 = ContractsGrantsInvoiceDetailFixture.INV_DTL8.createInvoiceDetail();
+        ContractsGrantsInvoiceDetail invoiceDetail_2 = ContractsGrantsInvoiceDetailFixture.INV_DTL9.createInvoiceDetail();
         List<ContractsGrantsInvoiceDetail> invoiceDetails = new ArrayList<ContractsGrantsInvoiceDetail>();
         invoiceDetails.add(invoiceDetail_1);
         invoiceDetails.add(invoiceDetail_2);
         contractsGrantsInvoiceDocument.setInvoiceDetails(invoiceDetails);
+
+        List<InvoiceDetailAccountObjectCode> invoiceDetailAccountObjectCodes = new ArrayList<>();
+        invoiceDetailAccountObjectCodes.add(InvoiceDetailAccountObjectCodeFixture.DETAIL_ACC_OBJ_CD4.createInvoiceDetailAccountObjectCode());
+        invoiceDetailAccountObjectCodes.add(InvoiceDetailAccountObjectCodeFixture.DETAIL_ACC_OBJ_CD5.createInvoiceDetailAccountObjectCode());
+        contractsGrantsInvoiceDocument.setInvoiceDetailAccountObjectCodes(invoiceDetailAccountObjectCodes);
 
         KualiDecimal value1 = new KualiDecimal(5);
 
@@ -1231,17 +1236,18 @@ public class ContractsGrantsInvoiceDocumentServiceTest extends KualiTestBase {
         InvoiceAccountDetail invoiceAccountDetail_2 = InvoiceAccountDetailFixture.INV_ACCT_DTL4.createInvoiceAccountDetail();
         List<InvoiceAccountDetail> accountDetails = new ArrayList<InvoiceAccountDetail>();
         accountDetails.add(invoiceAccountDetail_1);
+        accountDetails.add(invoiceAccountDetail_2);
         contractsGrantsInvoiceDocument.setAccountDetails(accountDetails);
 
 
         List<InvoiceMilestone> invoiceMilestones = new ArrayList<InvoiceMilestone>();
-        InvoiceMilestone invMilestone_1 = InvoiceMilestoneFixture.INV_MLSTN_1.createInvoiceMilestone();
+        InvoiceMilestone invMilestone_1 = InvoiceMilestoneFixture.INV_MLSTN_3.createInvoiceMilestone();
         invoiceMilestones.add(invMilestone_1);
         contractsGrantsInvoiceDocument.setInvoiceMilestones(invoiceMilestones);
 
 
         List<InvoiceBill> invoiceBills = new ArrayList<InvoiceBill>();
-        InvoiceBill invBill_1 = InvoiceBillFixture.INV_BILL_1.createInvoiceBill();
+        InvoiceBill invBill_1 = InvoiceBillFixture.INV_BILL_3.createInvoiceBill();
         invoiceBills.add(invBill_1);
         contractsGrantsInvoiceDocument.setInvoiceBills(invoiceBills);
 

--- a/test/unit/src/org/kuali/kfs/module/ar/fixture/ContractsGrantsInvoiceDetailFixture.java
+++ b/test/unit/src/org/kuali/kfs/module/ar/fixture/ContractsGrantsInvoiceDetailFixture.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -32,7 +32,9 @@ public enum ContractsGrantsInvoiceDetailFixture {
     INV_DTL4(new Long(2355), "6324", "SAL", new KualiDecimal(320.00), KualiDecimal.ZERO, new KualiDecimal(340.00), new KualiDecimal(-20.00), KualiDecimal.ZERO, false),
     INV_DTL5(new Long(2356), "6325", "EMPB", new KualiDecimal(320.00), KualiDecimal.ZERO, new KualiDecimal(340.00), new KualiDecimal(-20.00), KualiDecimal.ZERO, false),
     INV_DTL6(new Long(2357), "6326", "OIC", new KualiDecimal(320.00), KualiDecimal.ZERO, new KualiDecimal(340.00), new KualiDecimal(-20.00), KualiDecimal.ZERO, true),
-    INV_DTL7(new Long(2357), "6326", null, new KualiDecimal(300.00), KualiDecimal.ZERO, new KualiDecimal(300.00), new KualiDecimal(0.00), KualiDecimal.ZERO, true);
+    INV_DTL7(new Long(2357), "6326", null, new KualiDecimal(300.00), KualiDecimal.ZERO, new KualiDecimal(300.00), new KualiDecimal(0.00), KualiDecimal.ZERO, true),
+    INV_DTL8(new Long(2358), "6367", "SAL", KualiDecimal.ZERO, new KualiDecimal(5.0), KualiDecimal.ZERO, KualiDecimal.ZERO, KualiDecimal.ZERO, false),
+    INV_DTL9(new Long(2359), "6328", "EMPB", KualiDecimal.ZERO, new KualiDecimal(7.0), KualiDecimal.ZERO, KualiDecimal.ZERO, KualiDecimal.ZERO, false),;
 
     private Long invoiceDetailIdentifier;
     private String documentNumber;

--- a/test/unit/src/org/kuali/kfs/module/ar/fixture/CustomerInvoiceDetailFixture.java
+++ b/test/unit/src/org/kuali/kfs/module/ar/fixture/CustomerInvoiceDetailFixture.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -138,7 +138,7 @@ public enum CustomerInvoiceDetailFixture {
             Date.valueOf("2008-01-01"), // invoiceItemServiceDate
             new BigDecimal(1), // invoiceItemQuantity
             new BigDecimal(1), // invoiceItemUnitPrice
-            new KualiDecimal(1), // amount
+            new KualiDecimal(5), // amount
             new KualiDecimal(0) // invoiceItemTaxAmount
             , null),
 
@@ -169,7 +169,7 @@ public enum CustomerInvoiceDetailFixture {
             Date.valueOf("2008-01-01"), // invoiceItemServiceDate
             new BigDecimal(1), // invoiceItemQuantity
             new BigDecimal(1), // invoiceItemUnitPrice
-            new KualiDecimal(1), // amount
+            new KualiDecimal(5.0), // amount
             new KualiDecimal(0), // invoiceItemTaxAmount
             null),
     ZERO_DOLLAR_INVOICE_DETAIL(KualiDecimal.ZERO),

--- a/test/unit/src/org/kuali/kfs/module/ar/fixture/InvoiceBillFixture.java
+++ b/test/unit/src/org/kuali/kfs/module/ar/fixture/InvoiceBillFixture.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -29,7 +29,8 @@ import org.kuali.rice.core.api.util.type.KualiDecimal;
 public enum InvoiceBillFixture {
 
     INV_BILL_1("5030", new Long(1), "Bill 1", new Long(1), null, new KualiDecimal(1)),
-    INV_BILL_2("5030", new Long(2), "Bill 2", new Long(2), new Date(System.currentTimeMillis()), new KualiDecimal(1));
+    INV_BILL_2("5030", new Long(2), "Bill 2", new Long(2), new Date(System.currentTimeMillis()), new KualiDecimal(1)),
+    INV_BILL_3("5030", new Long(1), "Bill 1", new Long(1), null, new KualiDecimal(5));
 
     private String documentNumber;
     private Long billNumber;

--- a/test/unit/src/org/kuali/kfs/module/ar/fixture/InvoiceDetailAccountObjectCodeFixture.java
+++ b/test/unit/src/org/kuali/kfs/module/ar/fixture/InvoiceDetailAccountObjectCodeFixture.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -29,7 +29,9 @@ public enum InvoiceDetailAccountObjectCodeFixture {
 
     DETAIL_ACC_OBJ_CD1("6320", new Long(80072), "9000000", "IN", "2008", "SAL", KualiDecimal.ZERO, KualiDecimal.ZERO, KualiDecimal.ZERO),
     DETAIL_ACC_OBJ_CD2("6320", new Long(80072), "9000000", "IN", "2408", "EMPB", KualiDecimal.ZERO, KualiDecimal.ZERO, KualiDecimal.ZERO),
-    DETAIL_ACC_OBJ_CD3("6320", new Long(80072), "6044901", "BA", "2408", "EMPB", KualiDecimal.ZERO, KualiDecimal.ZERO, KualiDecimal.ZERO);
+    DETAIL_ACC_OBJ_CD3("6320", new Long(80072), "6044901", "BA", "2408", "EMPB", KualiDecimal.ZERO, KualiDecimal.ZERO, KualiDecimal.ZERO),
+    DETAIL_ACC_OBJ_CD4("6320", new Long(80072), "2336320", "BL", "2008", "SAL", new KualiDecimal(5.0), KualiDecimal.ZERO, KualiDecimal.ZERO),
+    DETAIL_ACC_OBJ_CD5("6320", new Long(80072), "1292016", "IN", "2408", "EMPB", new KualiDecimal(7.0), KualiDecimal.ZERO, KualiDecimal.ZERO);
 
     private String documentNumber;
     private Long proposalNumber;

--- a/test/unit/src/org/kuali/kfs/module/ar/fixture/InvoiceMilestoneFixture.java
+++ b/test/unit/src/org/kuali/kfs/module/ar/fixture/InvoiceMilestoneFixture.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -29,7 +29,8 @@ import org.kuali.rice.core.api.util.type.KualiDecimal;
 public enum InvoiceMilestoneFixture {
 
     INV_MLSTN_1("5030", new Long(1), new Long(1), "Milestone 1", new KualiDecimal(1), null),
-    INV_MLSTN_2("5030", new Long(2), new Long(2), "Milestone 2", new KualiDecimal(1), new Date(System.currentTimeMillis()));
+    INV_MLSTN_2("5030", new Long(2), new Long(2), "Milestone 2", new KualiDecimal(1), new Date(System.currentTimeMillis())),
+    INV_MLSTN_3("5030", new Long(1), new Long(1), "Milestone 3", new KualiDecimal(5), null);
 
     private String documentNumber;
     private Long milestoneNumber;

--- a/work/src/org/kuali/kfs/module/ar/document/service/impl/ContractsGrantsInvoiceDocumentServiceImpl.java
+++ b/work/src/org/kuali/kfs/module/ar/document/service/impl/ContractsGrantsInvoiceDocumentServiceImpl.java
@@ -204,7 +204,7 @@ public class ContractsGrantsInvoiceDocumentServiceImpl implements ContractsGrant
                     totalAmount = totalBillAmount;
                 }
                 else {
-                    final String accountKey = getAccountKeyFromInvoiceAccountDetail(invAcctD);
+                    final String accountKey = StringUtils.join(new String[] { invAcctD.getChartOfAccountsCode(), invAcctD.getAccountNumber() }, "-");
                     totalAmount = accountExpenditureAmounts.containsKey(accountKey)
                             ? accountExpenditureAmounts.get(accountKey)
                             : KualiDecimal.ZERO;
@@ -225,7 +225,7 @@ public class ContractsGrantsInvoiceDocumentServiceImpl implements ContractsGrant
     protected Map<String, KualiDecimal> getCategoryExpenditureAmountsForInvoiceAccountDetail(ContractsGrantsInvoiceDocument contractsGrantsInvoiceDocument) {
         Map<String, KualiDecimal> expenditureAmounts = new HashMap<>();
         for (InvoiceDetailAccountObjectCode invoiceDetailAccountObjectCode : contractsGrantsInvoiceDocument.getInvoiceDetailAccountObjectCodes()) {
-            final String accountKey = getAccountKeyFromInvoiceDetailAccountObjectCode(invoiceDetailAccountObjectCode);
+            final String accountKey = StringUtils.join(new String[] { invoiceDetailAccountObjectCode.getChartOfAccountsCode(), invoiceDetailAccountObjectCode.getAccountNumber() }, "-");
             if (!StringUtils.isBlank(invoiceDetailAccountObjectCode.getCategoryCode())) {
                 KualiDecimal total = expenditureAmounts.get(accountKey);
                 if (ObjectUtils.isNull(total)) {
@@ -235,24 +235,6 @@ public class ContractsGrantsInvoiceDocumentServiceImpl implements ContractsGrant
             }
         }
         return expenditureAmounts;
-    }
-
-    /**
-     * Builds a String in the form of the concatenation of chartOfAccountsCode-accountNumber for the given InvoiceDetailAccountObjectCode
-     * @param invoiceDetailAccountObjectCode an invoice detail account object code to concatenate the account primary key for
-     * @return the concatenated primary key for the account
-     */
-    protected String getAccountKeyFromInvoiceDetailAccountObjectCode(InvoiceDetailAccountObjectCode invoiceDetailAccountObjectCode) {
-        return StringUtils.join(new String[] { invoiceDetailAccountObjectCode.getChartOfAccountsCode(), invoiceDetailAccountObjectCode.getAccountNumber() }, "-");
-    }
-
-    /**
-     * Builds a String in the form of the concatenation of chartOfAccountsCode-accountNumber for the given InvoiceDetailAccount
-     * @param invoiceAccountDetail the invoice account detail to concatenate the account primary key for
-     * @return the concatenated primary key for the account
-     */
-    protected String getAccountKeyFromInvoiceAccountDetail(InvoiceAccountDetail invoiceAccountDetail) {
-        return StringUtils.join(new String[] { invoiceAccountDetail.getChartOfAccountsCode(), invoiceAccountDetail.getAccountNumber() }, "-");
     }
 
     /**
@@ -1869,20 +1851,11 @@ public class ContractsGrantsInvoiceDocumentServiceImpl implements ContractsGrant
                 final Map<String, KualiDecimal> accountExpenditureAmounts = getCategoryExpenditureAmountsForInvoiceAccountDetail(contractsGrantsInvoiceDocument);
                 for (Object al : contractsGrantsInvoiceDocument.getSourceAccountingLines()) {
                     final CustomerInvoiceDetail customerInvoiceDetail = (CustomerInvoiceDetail)al;
-                    final String accountKey = getAccountKeyFromCustomerInvoiceDetail(customerInvoiceDetail);
+                    final String accountKey = StringUtils.join(new String[] { customerInvoiceDetail.getChartOfAccountsCode(), customerInvoiceDetail.getAccountNumber() }, "-");
                     customerInvoiceDetail.setAmount(accountExpenditureAmounts.get(accountKey));
                 }
             }
         }
-    }
-
-    /**
-     * Builds a String in the form of the concatenation of chartOfAccountsCode-accountNumber for the given CustomerInvoiceDetail
-     * @param customerInvoiceDetailAccountObjectCode a customer invoice detail to concatenate the account primary key for
-     * @return the concatenated primary key for the account
-     */
-    protected String getAccountKeyFromCustomerInvoiceDetail(CustomerInvoiceDetail customerInvoiceDetail) {
-        return StringUtils.join(new String[] { customerInvoiceDetail.getChartOfAccountsCode(), customerInvoiceDetail.getAccountNumber() }, "-");
     }
 
     public ContractsAndGrantsModuleBillingService getContractsAndGrantsModuleBillingService() {


### PR DESCRIPTION
Update mocks so that ContractsGrantsInvoiceDocumentServiceTest:testCreateSourceAccountingLines correctly reflects updated logic about amounts.  Get rid of single line methods from ContractsGrantsInvoiceDocumentServiceImpl, because Java is silly