### PR TITLE
KFSTP-1788

### DIFF
--- a/work/src/org/kuali/kfs/module/ar/ArConstants.java
+++ b/work/src/org/kuali/kfs/module/ar/ArConstants.java
@@ -631,4 +631,5 @@ public class ArConstants{
     public static final String FROM_SUFFIX = " From";
     public static final String TO_SUFFIX = " To";
 
+    public static final String LETTER_OF_CREDIT_REVIEW_INIT_SECTION = "letterOfCreditReviewInitSection";
 }

--- a/work/src/org/kuali/kfs/module/ar/ArKeyConstants.java
+++ b/work/src/org/kuali/kfs/module/ar/ArKeyConstants.java
@@ -402,6 +402,9 @@ public class ArKeyConstants {
 
      public static final String LOC_REVIEW_CREATION_TYPE = "message.locreview.creation.type";
 
+     public static final String ERROR_LOC_REVIEW_FUND_OR_FUND_GROUP_REQUIRED = "error.locreview.fund.or.fund.group.required";
+     public static final String ERROR_LOC_REVIEW_ONLY_ONE_FUND_OR_FUND_GROUP = "error.locreview.only.one.fund.or.fund.group";
+
      // Final Billed Indicator Validation error messages
      public static final String ERROR_FINAL_BILLED_INDICATOR_INVOICE_NOT_FINAL = "error.final.billed.indicator.invoice.not.final";
      public static final String ERROR_FINAL_BILLED_INDICATOR_INVOICE_NOT_MARKED_FINAL_BILL = "error.final.billed.indicator.invoice.not.marked.final.bill";

--- a/work/src/org/kuali/kfs/module/ar/ar-resources.properties
+++ b/work/src/org/kuali/kfs/module/ar/ar-resources.properties
@@ -347,6 +347,8 @@ locreview.pdf.header.initiator.principal.name=Document Initiator:
 locreview.pdf.header.create.date=Document Creation Date: 
 locreview.pdf.subheader.awards=Awards
 message.locreview.creation.type=LOC Creation Type: {0} of value {1}
+error.locreview.fund.or.fund.group.required=The Letter of Credit Fund Group or the Letter of Credit Fund is required.
+error.locreview.only.one.fund.or.fund.group=Both values cannot be populated. Provide either the Letter of Credit Fund Group or the Letter of Credit Fund.
 
 # Final Billed Indicator Validation error messages
 error.final.billed.indicator.invoice.not.final=The Invoice is not Final.

--- a/work/src/org/kuali/kfs/module/ar/document/web/struts/ContractsGrantsLetterOfCreditReviewDocumentAction.java
+++ b/work/src/org/kuali/kfs/module/ar/document/web/struts/ContractsGrantsLetterOfCreditReviewDocumentAction.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -96,8 +96,10 @@ public class ContractsGrantsLetterOfCreditReviewDocumentAction extends KualiTran
         ContractsGrantsLetterOfCreditReviewDocumentForm contractsGrantsLetterOfCreditReviewDocumentForm = (ContractsGrantsLetterOfCreditReviewDocumentForm) form;
         ContractsGrantsLetterOfCreditReviewDocument contractsGrantsLetterOfCreditReviewDocument = (ContractsGrantsLetterOfCreditReviewDocument) contractsGrantsLetterOfCreditReviewDocumentForm.getDocument();
 
-        if (StringUtils.isEmpty(contractsGrantsLetterOfCreditReviewDocument.getLetterOfCreditFundGroupCode()) || StringUtils.isBlank(contractsGrantsLetterOfCreditReviewDocument.getLetterOfCreditFundGroupCode())) {
-            GlobalVariables.getMessageMap().putError(ArConstants.LETTER_OF_CREDIT_FUND_GROUP_PROPERTY, KFSKeyConstants.ERROR_REQUIRED, ArConstants.LETTER_OF_CREDIT_FUND_GROUP);
+        if (StringUtils.isBlank(contractsGrantsLetterOfCreditReviewDocument.getLetterOfCreditFundCode()) && StringUtils.isBlank(contractsGrantsLetterOfCreditReviewDocument.getLetterOfCreditFundGroupCode())) {
+            GlobalVariables.getMessageMap().putError(ArConstants.LETTER_OF_CREDIT_REVIEW_INIT_SECTION, ArKeyConstants.ERROR_LOC_REVIEW_FUND_OR_FUND_GROUP_REQUIRED);
+        } else if (!StringUtils.isBlank(contractsGrantsLetterOfCreditReviewDocument.getLetterOfCreditFundCode()) && !StringUtils.isBlank(contractsGrantsLetterOfCreditReviewDocument.getLetterOfCreditFundGroupCode())) {
+            GlobalVariables.getMessageMap().putError(ArConstants.LETTER_OF_CREDIT_REVIEW_INIT_SECTION, ArKeyConstants.ERROR_LOC_REVIEW_ONLY_ONE_FUND_OR_FUND_GROUP);
         }
         else {
             ContractsGrantsLetterOfCreditReviewDocument document = (ContractsGrantsLetterOfCreditReviewDocument) SpringContext.getBean(DocumentService.class).getByDocumentHeaderId(contractsGrantsLetterOfCreditReviewDocument.getDocumentNumber());

--- a/work/web-root/WEB-INF/tags/module/ar/contractsGrantsLetterOfCreditReviewInit.tag
+++ b/work/web-root/WEB-INF/tags/module/ar/contractsGrantsLetterOfCreditReviewInit.tag
@@ -20,19 +20,18 @@
 
 <c:set var="documentAttributes" value="${DataDictionary.ContractsGrantsLetterOfCreditReviewDocument.attributes}" />
 
-<kul:tabTop tabTitle="Contracts Grants LOC Review Initiation" defaultOpen="true" tabErrorKey="*">
+<kul:tabTop tabTitle="Contracts Grants LOC Review Initiation" defaultOpen="true" tabErrorKey="${ArConstants.LETTER_OF_CREDIT_REVIEW_INIT_SECTION},document.letterOfCreditFundGroupCode,document.letterOfCreditFundCode">
 	<div class="tab-container" align=center>
 		<h3>Contracts Grants LOC Review Initiation</h3>
 		<table cellpadding="0" cellspacing="0" class="datatable" summary="Credit Memo Init Section">
 			<tr>
 				<th align=right valign=middle class="bord-l-b">
 					<div align="right">
-						<kul:htmlAttributeLabel attributeEntry="${documentAttributes.letterOfCreditFundGroupCode}" forceRequired="true" />
+						<kul:htmlAttributeLabel attributeEntry="${documentAttributes.letterOfCreditFundGroupCode}"/>
 					</div>
 				</th>
 				<td align=left valign=middle class="datacell" style="width: 50%;"><kul:htmlControlAttribute
-						attributeEntry="${documentAttributes.letterOfCreditFundGroupCode}" property="document.letterOfCreditFundGroupCode" readOnly="false"
-						forceRequired="true" /></td>
+						attributeEntry="${documentAttributes.letterOfCreditFundGroupCode}" property="document.letterOfCreditFundGroupCode" readOnly="false"/></td>
 			</tr>
 			<tr>
 				<th align=right valign=middle class="bord-l-b">


### PR DESCRIPTION
Do not require fund group code on LoC Review doc init; instead, verify that at least one but no more than one is chosen and show appropriate error message if both or zero are chosen.