### PR TITLE
KFSTP-1816

### DIFF
--- a/test/unit/src/org/kuali/kfs/module/ar/fixture/ARAwardAccountFixture.java
+++ b/test/unit/src/org/kuali/kfs/module/ar/fixture/ARAwardAccountFixture.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,20 +21,19 @@ package org.kuali.kfs.module.ar.fixture;
 import java.sql.Date;
 
 import org.kuali.kfs.module.cg.businessobject.AwardAccount;
-import org.kuali.rice.core.api.util.type.KualiDecimal;
 
 /**
  * Fixture class for CG AwardAccount
  */
 public enum ARAwardAccountFixture {
 
-    AWD_ACCT_1(new Long(11), "BL", "2336320", false, null, null, new KualiDecimal(1), false),
-    AWD_ACCT_2(new Long(11), "IN", "1292016", false, null, null, new KualiDecimal(1), false),
-    AWD_ACCT_3(new Long(11), "BL", "1024697", false, null, null, new KualiDecimal(1), false),
-    AWD_ACCT_4(new Long(11), "BA", "6044901", false, null, null, new KualiDecimal(1), false),
-    AWD_ACCT_WITH_CCA_1(new Long(11), "BL", "1020087", false, null, null, new KualiDecimal(1), false),
-    AWD_ACCT_WITH_CCA_2(new Long(11), "BL", "1021887", false, null, null, new KualiDecimal(1), false),
-    AWD_ACCT_WITH_CCA_3(new Long(11), "BL", "2424704", false, null, null, new KualiDecimal(1), false);
+    AWD_ACCT_1(new Long(11), "BL", "2336320", false, null, null),
+    AWD_ACCT_2(new Long(11), "IN", "1292016", false, null, null),
+    AWD_ACCT_3(new Long(11), "BL", "1024697", false, null, null),
+    AWD_ACCT_4(new Long(11), "BA", "6044901", false, null, null),
+    AWD_ACCT_WITH_CCA_1(new Long(11), "BL", "1020087", false, null, null),
+    AWD_ACCT_WITH_CCA_2(new Long(11), "BL", "1021887", false, null, null),
+    AWD_ACCT_WITH_CCA_3(new Long(11), "BL", "2424704", false, null, null);
 
     private Long proposalNumber;
     private String chartOfAccountsCode;
@@ -43,11 +42,9 @@ public enum ARAwardAccountFixture {
     private boolean finalBilledIndicator;
     private Date currentLastBilledDate;
     private Date previousLastBilledDate;
-    private KualiDecimal amountToDraw = KualiDecimal.ZERO;
-    private boolean locReviewIndicator;
 
 
-    private ARAwardAccountFixture(Long proposalNumber, String chartOfAccountsCode, String accountNumber, boolean finalBilledIndicator, Date currentLastBilledDate, Date previousLastBilledDate, KualiDecimal amountToDraw, boolean locReviewIndicator) {
+    private ARAwardAccountFixture(Long proposalNumber, String chartOfAccountsCode, String accountNumber, boolean finalBilledIndicator, Date currentLastBilledDate, Date previousLastBilledDate) {
 
         this.proposalNumber = proposalNumber;
         this.chartOfAccountsCode = chartOfAccountsCode;
@@ -55,8 +52,6 @@ public enum ARAwardAccountFixture {
         this.finalBilledIndicator = finalBilledIndicator;
         this.currentLastBilledDate = currentLastBilledDate;
         this.previousLastBilledDate = previousLastBilledDate;
-        this.amountToDraw = amountToDraw;
-        this.locReviewIndicator = locReviewIndicator;
 
 
     }
@@ -70,8 +65,6 @@ public enum ARAwardAccountFixture {
         awardAccount.setFinalBilledIndicator(this.finalBilledIndicator);
         awardAccount.setCurrentLastBilledDate(this.currentLastBilledDate);
         awardAccount.setPreviousLastBilledDate(this.previousLastBilledDate);
-        awardAccount.setAmountToDraw(this.amountToDraw);
-        awardAccount.setLetterOfCreditReviewIndicator(this.locReviewIndicator);
         return awardAccount;
     }
 }

--- a/test/unit/src/org/kuali/kfs/module/cg/fixture/AwardAccountFixture.java
+++ b/test/unit/src/org/kuali/kfs/module/cg/fixture/AwardAccountFixture.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,14 +21,14 @@ package org.kuali.kfs.module.cg.fixture;
 import java.sql.Date;
 
 import org.kuali.kfs.module.cg.businessobject.AwardAccount;
-import org.kuali.rice.core.api.util.type.KualiDecimal;
 
 /**
  * Fixture class for AwardAccount
  */
 public enum AwardAccountFixture {
 
-    AWD_ACCT_1(new Long(111), "BL", "1031400", false, null, null, new KualiDecimal(1), false), AWD_ACCT_2(new Long(111), "BL", "0142900", false, null, null, new KualiDecimal(1), false);
+    AWD_ACCT_1(new Long(111), "BL", "1031400", false, null, null),
+    AWD_ACCT_2(new Long(111), "BL", "0142900", false, null, null);
 
     private Long proposalNumber;
     private String chartOfAccountsCode;
@@ -37,22 +37,14 @@ public enum AwardAccountFixture {
     private boolean finalBilledIndicator;
     private Date currentLastBilledDate;
     private Date previousLastBilledDate;
-    private KualiDecimal amountToDraw = KualiDecimal.ZERO;
-    private boolean locReviewIndicator;
 
-
-    private AwardAccountFixture(Long proposalNumber, String chartOfAccountsCode, String accountNumber, boolean finalBilledIndicator, Date currentLastBilledDate, Date previousLastBilledDate, KualiDecimal amountToDraw, boolean locReviewIndicator) {
-
+    private AwardAccountFixture(Long proposalNumber, String chartOfAccountsCode, String accountNumber, boolean finalBilledIndicator, Date currentLastBilledDate, Date previousLastBilledDate) {
         this.proposalNumber = proposalNumber;
         this.chartOfAccountsCode = chartOfAccountsCode;
         this.accountNumber = accountNumber;
         this.finalBilledIndicator = finalBilledIndicator;
         this.currentLastBilledDate = currentLastBilledDate;
         this.previousLastBilledDate = previousLastBilledDate;
-        this.amountToDraw = amountToDraw;
-        this.locReviewIndicator = locReviewIndicator;
-
-
     }
 
     public AwardAccount createAwardAccount() {
@@ -64,8 +56,6 @@ public enum AwardAccountFixture {
         awardAccount.setFinalBilledIndicator(this.finalBilledIndicator);
         awardAccount.setCurrentLastBilledDate(this.currentLastBilledDate);
         awardAccount.setPreviousLastBilledDate(this.previousLastBilledDate);
-        awardAccount.setAmountToDraw(this.amountToDraw);
-        awardAccount.setLetterOfCreditReviewIndicator(this.locReviewIndicator);
         return awardAccount;
     }
 }

--- a/work/db/upgrades/5.0.3_cgb/db/01_structure/cg-module-structure-updates.xml
+++ b/work/db/upgrades/5.0.3_cgb/db/01_structure/cg-module-structure-updates.xml
@@ -156,8 +156,6 @@
 		</addColumn>
 		<addColumn tableName="CG_AWD_ACCT_T">
 			<column name="FNL_BILLED_IND" type="VARCHAR(1)" />
-			<column name="AMT_TO_DRW" type="DECIMAL(19,2)" />
-			<column name="LTRCR_RVW_IND" type="VARCHAR(1)" />
 			<column name="CURR_LST_BILLED_DT" type="DATETIME" />
 			<column name="PREV_LST_BILLED_DT" type="DATETIME" />
 		</addColumn>
@@ -172,7 +170,6 @@
 			<column name="AUTO_APPROVE_IND" type="VARCHAR(1)" />
 			<column name="FUNDING_EXP_DT" type="DATETIME" />
 			<column name="INV_OPT_CD" type="VARCHAR(1)" />
-			<column name="LTRCR_CRTN_TYP" type="VARCHAR(45)" />
 			<column name="EXCL_FRM_INV_REASON_TXT" type="VARCHAR(255)" />
 			<column name="STATE_TRNSFR_IND" type="VARCHAR(1)" />
 			<column name="CMPGN_ID" type="VARCHAR(4)" />

--- a/work/src/org/kuali/kfs/integration/cg/ContractsAndGrantsBillingAward.java
+++ b/work/src/org/kuali/kfs/integration/cg/ContractsAndGrantsBillingAward.java
@@ -230,13 +230,6 @@ public interface ContractsAndGrantsBillingAward extends ContractsAndGrantsAward 
     public String getAgencyNumber();
 
     /**
-     * Gets the letterOfCreditCreationType attribute.
-     *
-     * @return Returns the letterOfCreditCreationType.
-     */
-    public String getLetterOfCreditCreationType();
-
-    /**
      * Gets the federalPassThroughAgencyNumber attribute.
      *
      * @return Returns the federalPassThroughAgencyNumber.

--- a/work/src/org/kuali/kfs/integration/cg/ContractsAndGrantsBillingAwardAccount.java
+++ b/work/src/org/kuali/kfs/integration/cg/ContractsAndGrantsBillingAwardAccount.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,15 +20,10 @@ package org.kuali.kfs.integration.cg;
 
 import java.sql.Date;
 
-import org.kuali.rice.core.api.util.type.KualiDecimal;
-
 /**
  * Integration interface for AwardAccount
  */
 public interface ContractsAndGrantsBillingAwardAccount extends ContractsAndGrantsAccountAwardInformation{
-
-
-
     /**
      * Gets the currentLastBilledDate attribute.
      *
@@ -49,19 +44,4 @@ public interface ContractsAndGrantsBillingAwardAccount extends ContractsAndGrant
      * @return Returns the finalBilledIndicator.
      */
     public boolean isFinalBilledIndicator();
-
-
-    /**
-     * Gets the amountToDraw attribute.
-     *
-     * @return Returns the amountToDraw.
-     */
-    public KualiDecimal getAmountToDraw();
-
-    /**
-     * Gets the letterOfCreditReviewIndicator attribute.
-     *
-     * @return Returns the letterOfCreditReviewIndicator.
-     */
-    public boolean isLetterOfCreditReviewIndicator();
 }

--- a/work/src/org/kuali/kfs/integration/cg/ContractsAndGrantsModuleBillingService.java
+++ b/work/src/org/kuali/kfs/integration/cg/ContractsAndGrantsModuleBillingService.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,8 +20,6 @@ package org.kuali.kfs.integration.cg;
 
 import java.util.List;
 import java.util.Map;
-
-import org.kuali.rice.core.api.util.type.KualiDecimal;
 
 /**
  * Module service specific to those methods needed to support Contracts & Grants Billing.
@@ -65,30 +63,6 @@ public interface ContractsAndGrantsModuleBillingService {
      * @param lastBilledDate
      */
     public void setLastBilledDateToAward(Long proposalNumber, java.sql.Date lastBilledDate);
-
-    /**
-     * This method sets value of LOC Creation Type to Award
-     *
-     * @param proposalNumber
-     * @param locCreationType
-     */
-    public void setLOCCreationTypeToAward(Long proposalNumber, String locCreationType);
-
-    /**
-     * This method sets amount to draw to award Account.
-     *
-     * @param criteria
-     * @param amountToDraw
-     */
-    public void setAmountToDrawToAwardAccount(Map<String, Object> criteria, KualiDecimal amountToDraw);
-
-    /**
-     * This method sets loc review indicator to award Account.
-     *
-     * @param criteria
-     * @param locReviewIndicator
-     */
-    public void setLOCReviewIndicatorToAwardAccount(Map<String, Object> criteria, boolean locReviewIndicator);
 
     /**
      * This method sets final billed to award Account.

--- a/work/src/org/kuali/kfs/integration/cg/ContractsAndGrantsModuleBillingServiceNoOp.java
+++ b/work/src/org/kuali/kfs/integration/cg/ContractsAndGrantsModuleBillingServiceNoOp.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,8 +22,6 @@ import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import org.kuali.rice.core.api.util.type.KualiDecimal;
 
 /**
  * Do nothing implementation of the ContractsAndGrantsModuleBillingService interface
@@ -68,35 +66,6 @@ public class ContractsAndGrantsModuleBillingServiceNoOp implements ContractsAndG
         LOG.warn("Using No-Op " + getClass().getSimpleName() + " service.");
 
     }
-
-    /**
-     * @see org.kuali.kfs.integration.cg.ContractsAndGrantsModuleUpdateService#setLOCCreationTypeToAward(java.lang.Long,
-     *      java.lang.String)
-     */
-    @Override
-    public void setLOCCreationTypeToAward(Long proposalNumber, String locCreationType) {
-        LOG.warn("Using No-Op " + getClass().getSimpleName() + " service.");
-    }
-
-    /**
-     * @see org.kuali.kfs.integration.cg.ContractsAndGrantsModuleUpdateService#setAmountToDrawToAwardAccount(java.util.Map,
-     *      org.kuali.rice.core.api.util.type.KualiDecimal)
-     */
-    @Override
-    public void setAmountToDrawToAwardAccount(Map<String, Object> criteria, KualiDecimal amountToDraw) {
-        LOG.warn("Using No-Op " + getClass().getSimpleName() + " service.");
-    }
-
-
-    /**
-     * @see org.kuali.kfs.integration.cg.ContractsAndGrantsModuleUpdateService#setLOCReviewIndicatorToAwardAccount(java.util.Map,
-     *      boolean)
-     */
-    @Override
-    public void setLOCReviewIndicatorToAwardAccount(Map<String, Object> criteria, boolean locReviewIndicator) {
-        LOG.warn("Using No-Op " + getClass().getSimpleName() + " service.");
-    }
-
 
     /**
      * @see org.kuali.kfs.integration.cg.ContractsAndGrantsModuleUpdateService#setFinalBilledToAwardAccount(java.util.Map, boolean)

--- a/work/src/org/kuali/kfs/integration/cg/businessobject/Award.java
+++ b/work/src/org/kuali/kfs/integration/cg/businessobject/Award.java
@@ -81,7 +81,6 @@ public class Award implements ContractsAndGrantsBillingAward {
     private String letterOfCreditFundCode;
     private String grantDescriptionCode;
     private String agencyNumber;
-    private String letterOfCreditCreationType; // To create LOC
     private String federalPassThroughAgencyNumber;
     private String agencyAnalystName;
     private String analystTelephoneNumber;
@@ -698,28 +697,6 @@ public class Award implements ContractsAndGrantsBillingAward {
     public void setAgencyNumber(String agencyNumber) {
         this.agencyNumber = agencyNumber;
     }
-
-
-    /**
-     * Gets the letterOfCreditCreationType attribute.
-     *
-     * @return Returns the letterOfCreditCreationType.
-     */
-    @Override
-    public String getLetterOfCreditCreationType() {
-        return letterOfCreditCreationType;
-    }
-
-
-    /**
-     * Sets the letterOfCreditCreationType attribute value.
-     *
-     * @param letterOfCreditCreationType The letterOfCreditCreationType to set.
-     */
-    public void setLetterOfCreditCreationType(String letterOfCreditCreationType) {
-        this.letterOfCreditCreationType = letterOfCreditCreationType;
-    }
-
 
     /**
      * Gets the federalPassThroughAgencyNumber attribute.

--- a/work/src/org/kuali/kfs/integration/cg/businessobject/AwardAccount.java
+++ b/work/src/org/kuali/kfs/integration/cg/businessobject/AwardAccount.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -25,7 +25,6 @@ import org.kuali.kfs.coa.businessobject.Account;
 import org.kuali.kfs.coa.businessobject.Chart;
 import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAwardAccount;
 import org.kuali.rice.core.api.mo.common.active.MutableInactivatable;
-import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.krad.util.ObjectUtils;
 
@@ -42,54 +41,11 @@ public class AwardAccount implements ContractsAndGrantsBillingAwardAccount, Muta
     private Date currentLastBilledDate;
     private Date previousLastBilledDate;
     private boolean finalBilledIndicator;
-    private KualiDecimal amountToDraw = KualiDecimal.ZERO;
-    private boolean letterOfCreditReviewIndicator;
     private boolean active = true;
 
     private Account account;
     private Chart chartOfAccounts;
     private Person projectDirector;
-
-    /**
-     * Gets the amountToDraw attribute.
-     *
-     * @return Returns the amountToDraw.
-     */
-
-    @Override
-    public KualiDecimal getAmountToDraw() {
-        return amountToDraw;
-    }
-
-    /**
-     * Sets the amountToDraw attribute value.
-     *
-     * @param amountToDraw The amountToDraw to set.
-     */
-    public void setAmountToDraw(KualiDecimal amountToDraw) {
-        this.amountToDraw = amountToDraw;
-    }
-
-    /**
-     * Gets the letterOfCreditReviewIndicator attribute.
-     *
-     * @return Returns the letterOfCreditReviewIndicator.
-     */
-
-    @Override
-    public boolean isLetterOfCreditReviewIndicator() {
-        return letterOfCreditReviewIndicator;
-    }
-
-    /**
-     * Sets the letterOfCreditReviewIndicator attribute value.
-     *
-     * @param letterOfCreditReviewIndicator The letterOfCreditReviewIndicator to set.
-     */
-    public void setLetterOfCreditReviewIndicator(boolean letterOfCreditReviewIndicator) {
-        this.letterOfCreditReviewIndicator = letterOfCreditReviewIndicator;
-    }
-
 
     /**
      * Gets the finalBilledIndicator attribute.

--- a/work/src/org/kuali/kfs/module/ar/document/ContractsGrantsLetterOfCreditReviewDocument.java
+++ b/work/src/org/kuali/kfs/module/ar/document/ContractsGrantsLetterOfCreditReviewDocument.java
@@ -33,7 +33,6 @@ import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAward;
 import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAwardAccount;
 import org.kuali.kfs.integration.cg.ContractsAndGrantsLetterOfCreditFund;
 import org.kuali.kfs.integration.cg.ContractsAndGrantsLetterOfCreditFundGroup;
-import org.kuali.kfs.integration.cg.ContractsAndGrantsModuleBillingService;
 import org.kuali.kfs.module.ar.ArConstants;
 import org.kuali.kfs.module.ar.ArKeyConstants;
 import org.kuali.kfs.module.ar.ArPropertyConstants;
@@ -370,24 +369,6 @@ public class ContractsGrantsLetterOfCreditReviewDocument extends FinancialSystem
                 GlobalVariables.getMessageMap().putError(ArPropertyConstants.FUNDS_NOT_DRAWN, ArKeyConstants.ContractsGrantsInvoiceConstants.ERROR_DOCUMENT_AMOUNT_TO_DRAW_INVALID);
                 detail.setFundsNotDrawn(KualiDecimal.ZERO);
                 detail.setAmountToDraw(detail.getHiddenAmountToDraw().subtract(detail.getFundsNotDrawn()));
-            }
-
-            if (detail.getHiddenAmountToDraw().compareTo(detail.getAmountToDraw()) != 0) {
-                // This means the amount to Draw field has been changed,so
-
-                // a. set locreview indicator to yes in award account
-                // b.then set amounts to draw in award account
-                for (ContractsAndGrantsBillingAwardAccount awardAccount : award.getActiveAwardAccounts()) {
-                    // set the amount to Draw in the award Account
-                    Map<String, Object> criteria = new HashMap<String, Object>();
-                    criteria.put(KFSPropertyConstants.ACCOUNT_NUMBER, awardAccount.getAccountNumber());
-                    criteria.put(KFSPropertyConstants.CHART_OF_ACCOUNTS_CODE, awardAccount.getChartOfAccountsCode());
-                    criteria.put(KFSPropertyConstants.PROPOSAL_NUMBER, awardAccount.getProposalNumber());
-                    if (detail.getAccountNumber().equals(awardAccount.getAccountNumber())) {
-                        SpringContext.getBean(ContractsAndGrantsModuleBillingService.class).setAmountToDrawToAwardAccount(criteria, detail.getAmountToDraw());
-                        SpringContext.getBean(ContractsAndGrantsModuleBillingService.class).setLOCReviewIndicatorToAwardAccount(criteria, true);
-                    }
-                }
             }
         }
 

--- a/work/src/org/kuali/kfs/module/ar/document/service/impl/ContractsGrantsLetterOfCreditReviewDocumentServiceImpl.java
+++ b/work/src/org/kuali/kfs/module/ar/document/service/impl/ContractsGrantsLetterOfCreditReviewDocumentServiceImpl.java
@@ -144,20 +144,6 @@ public class ContractsGrantsLetterOfCreditReviewDocumentServiceImpl implements C
         }
 
         getContractsGrantsInvoiceCreateDocumentService().routeContractsGrantsInvoiceDocuments();
-
-        // The next important step is to set the locReviewIndicator to false and amount to Draw fields in award Account to zero.
-        // This should not affect any further invoicing.
-        for (ContractsAndGrantsBillingAward award : awards) {
-            for (ContractsAndGrantsBillingAwardAccount awardAccount : award.getActiveAwardAccounts()) {
-                Map<String, Object> criteria = new HashMap<String, Object>();
-                criteria.put(KFSPropertyConstants.ACCOUNT_NUMBER, awardAccount.getAccountNumber());
-                criteria.put(KFSPropertyConstants.CHART_OF_ACCOUNTS_CODE, awardAccount.getChartOfAccountsCode());
-                criteria.put(KFSPropertyConstants.PROPOSAL_NUMBER, awardAccount.getProposalNumber());
-                SpringContext.getBean(ContractsAndGrantsModuleBillingService.class).setAmountToDrawToAwardAccount(criteria, KualiDecimal.ZERO);
-                SpringContext.getBean(ContractsAndGrantsModuleBillingService.class).setLOCReviewIndicatorToAwardAccount(criteria, false);
-            }
-            SpringContext.getBean(ContractsAndGrantsModuleBillingService.class).setLOCCreationTypeToAward(award.getProposalNumber(), null);
-        }
     }
 
     /**

--- a/work/src/org/kuali/kfs/module/ar/service/impl/ContractsGrantsInvoiceCreateDocumentServiceImpl.java
+++ b/work/src/org/kuali/kfs/module/ar/service/impl/ContractsGrantsInvoiceCreateDocumentServiceImpl.java
@@ -1246,7 +1246,7 @@ public class ContractsGrantsInvoiceCreateDocumentServiceImpl implements Contract
         document.setOpenInvoiceIndicator(true);
 
         // To set LOC creation type and appropriate values from award.
-        if (StringUtils.isNotEmpty(award.getLetterOfCreditCreationType())) {
+        if (!StringUtils.isBlank(locCreationType)) {
             document.getInvoiceGeneralDetail().setLetterOfCreditCreationType(locCreationType);
         }
         // To set up values for Letter of Credit Fund and Fund Group irrespective of the LOC Creation type.

--- a/work/src/org/kuali/kfs/module/cg/businessobject/Award.java
+++ b/work/src/org/kuali/kfs/module/cg/businessobject/Award.java
@@ -88,7 +88,6 @@ public class Award extends PersistableBusinessObjectBase implements MutableInact
     private String letterOfCreditFundCode;
     private String grantDescriptionCode;
     private String agencyNumber;
-    private String letterOfCreditCreationType; // To create LOC
     private String federalPassThroughAgencyNumber;
     private String agencyAnalystName;
     private String analystTelephoneNumber;
@@ -1711,27 +1710,6 @@ public class Award extends PersistableBusinessObjectBase implements MutableInact
     public void setLookupFundMgrPerson(Person lookupFundMgrPerson) {
         this.lookupFundMgrPerson = lookupFundMgrPerson;
     }
-
-    /**
-     * Gets the letterOfCreditCreationType attribute.
-     *
-     * @return Returns the letterOfCreditCreationType.
-     */
-
-    @Override
-    public String getLetterOfCreditCreationType() {
-        return letterOfCreditCreationType;
-    }
-
-    /**
-     * Sets the letterOfCreditCreationType attribute value.
-     *
-     * @param letterOfCreditCreationType The letterOfCreditCreationType to set.
-     */
-    public void setLetterOfCreditCreationType(String letterOfCreditCreationType) {
-        this.letterOfCreditCreationType = letterOfCreditCreationType;
-    }
-
 
     /**
      * Gets the fundingExpirationDate attribute.

--- a/work/src/org/kuali/kfs/module/cg/businessobject/AwardAccount.java
+++ b/work/src/org/kuali/kfs/module/cg/businessobject/AwardAccount.java
@@ -28,7 +28,6 @@ import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAwardAccount;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.core.api.mo.common.active.MutableInactivatable;
-import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.kim.api.identity.PersonService;
 import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
@@ -49,8 +48,6 @@ public class AwardAccount extends PersistableBusinessObjectBase implements CGPro
     private boolean finalBilledIndicator;
     private Date currentLastBilledDate;
     private Date previousLastBilledDate;
-    private KualiDecimal amountToDraw = KualiDecimal.ZERO;// Amount to Draw when awards are pulled up for review.
-    private boolean letterOfCreditReviewIndicator;// The indicator set if the award account amountToDraw is modified by the user.
 
     private Account account;
     private Chart chartOfAccounts;
@@ -243,8 +240,6 @@ public class AwardAccount extends PersistableBusinessObjectBase implements CGPro
         m.put("finalBilledIndicator", this.finalBilledIndicator);
         m.put("currentLastBilledDate", this.currentLastBilledDate);
         m.put("previousLastBilledDate", this.previousLastBilledDate);
-        m.put("amountToDraw", this.amountToDraw);
-        m.put("letterOfCreditReviewIndicator", this.letterOfCreditReviewIndicator);
         return m;
     }
 
@@ -278,46 +273,6 @@ public class AwardAccount extends PersistableBusinessObjectBase implements CGPro
     @Override
     public void setActive(boolean active) {
         this.active = active;
-    }
-
-    /**
-     * Gets the letterOfCreditReviewIndicator attribute.
-     *
-     * @return Returns the letterOfCreditReviewIndicator.
-     */
-
-    @Override
-    public boolean isLetterOfCreditReviewIndicator() {
-        return letterOfCreditReviewIndicator;
-    }
-
-    /**
-     * Sets the letterOfCreditReviewIndicator attribute value.
-     *
-     * @param letterOfCreditReviewIndicator The letterOfCreditReviewIndicator to set.
-     */
-    public void setLetterOfCreditReviewIndicator(boolean letterOfCreditReviewIndicator) {
-        this.letterOfCreditReviewIndicator = letterOfCreditReviewIndicator;
-    }
-
-    /**
-     * Gets the amountToDraw attribute.
-     *
-     * @return Returns the amountToDraw.
-     */
-
-    @Override
-    public KualiDecimal getAmountToDraw() {
-        return amountToDraw;
-    }
-
-    /**
-     * Sets the amountToDraw attribute value.
-     *
-     * @param amountToDraw The amountToDraw to set.
-     */
-    public void setAmountToDraw(KualiDecimal amountToDraw) {
-        this.amountToDraw = amountToDraw;
     }
 
     /**

--- a/work/src/org/kuali/kfs/module/cg/ojb-cg.xml
+++ b/work/src/org/kuali/kfs/module/cg/ojb-cg.xml
@@ -380,7 +380,6 @@
 		<field-descriptor name="minInvoiceAmount" column="MIN_INV_AMT" jdbc-type="DECIMAL"
 			conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
 		<field-descriptor name="invoicingOptionCode" column="INV_OPT_CD" jdbc-type="VARCHAR" />
-		<field-descriptor name="letterOfCreditCreationType" column="LTRCR_CRTN_TYP" jdbc-type="VARCHAR" />
 		<field-descriptor name="autoApproveIndicator" column="AUTO_APPROVE_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
 		<field-descriptor name="active" column="ROW_ACTV_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
 		<field-descriptor name="billingFrequencyCode" column="BILL_FREQ_CD" jdbc-type="VARCHAR" />
@@ -501,8 +500,6 @@
 		<field-descriptor name="principalId" column="PERSON_UNVL_ID" jdbc-type="VARCHAR" index="true" />
 		<field-descriptor name="active" column="ROW_ACTV_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
 		<field-descriptor name="finalBilledIndicator" column="FNL_BILLED_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
-		<field-descriptor name="amountToDraw" column="AMT_TO_DRW" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
-		<field-descriptor name="letterOfCreditReviewIndicator" column="LTRCR_RVW_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
 		<field-descriptor name="currentLastBilledDate" column="CURR_LST_BILLED_DT" jdbc-type="DATE" />
 		<field-descriptor name="previousLastBilledDate" column="PREV_LST_BILLED_DT" jdbc-type="DATE" />
 		<reference-descriptor name="award" class-ref="org.kuali.kfs.module.cg.businessobject.Award" auto-retrieve="true" auto-update="none"

--- a/work/src/org/kuali/kfs/module/cg/service/impl/ContractsAndGrantsModuleBillingServiceImpl.java
+++ b/work/src/org/kuali/kfs/module/cg/service/impl/ContractsAndGrantsModuleBillingServiceImpl.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -29,7 +29,6 @@ import org.kuali.kfs.integration.cg.ContractsAndGrantsModuleBillingService;
 import org.kuali.kfs.module.cg.businessobject.Award;
 import org.kuali.kfs.module.cg.businessobject.AwardAccount;
 import org.kuali.kfs.module.cg.service.AwardService;
-import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.krad.service.BusinessObjectService;
 import org.kuali.rice.krad.service.LookupService;
 import org.kuali.rice.krad.util.ObjectUtils;
@@ -144,46 +143,6 @@ public class ContractsAndGrantsModuleBillingServiceImpl implements ContractsAndG
     @Override
     public void setLastBilledDateToAward(Long proposalNumber, Date lastBilledDate) {
         // This is a No-Op since getLastBilledDate on the CG Award is deriving the value from the AwardAccounts
-    }
-
-    /**
-     * This method sets value of LOC Creation Type to Award
-     *
-     * @param proposalNumber
-     * @param locCreationType
-     */
-    @Override
-    public void setLOCCreationTypeToAward(Long proposalNumber, String locCreationType) {
-        Award award = getBusinessObjectService().findBySinglePrimaryKey(Award.class, proposalNumber);
-
-        award.setLetterOfCreditCreationType(locCreationType);
-        getBusinessObjectService().save(award);
-    }
-
-    /**
-     * This method sets amount to draw to award Account.
-     *
-     * @param criteria
-     * @param amountToDraw
-     */
-    @Override
-    public void setAmountToDrawToAwardAccount(Map<String, Object> criteria, KualiDecimal amountToDraw) {
-        AwardAccount awardAccount = getBusinessObjectService().findByPrimaryKey(AwardAccount.class, criteria);
-        awardAccount.setAmountToDraw(amountToDraw);
-        getBusinessObjectService().save(awardAccount);
-    }
-
-    /**
-     * This method sets loc review indicator to award Account.
-     *
-     * @param criteria
-     * @param locReviewIndicator
-     */
-    @Override
-    public void setLOCReviewIndicatorToAwardAccount(Map<String, Object> criteria, boolean locReviewIndicator) {
-        AwardAccount awardAccount = getBusinessObjectService().findByPrimaryKey(AwardAccount.class, criteria);
-        awardAccount.setLetterOfCreditReviewIndicator(locReviewIndicator);
-        getBusinessObjectService().save(awardAccount);
     }
 
     /**

--- a/work/src/org/kuali/kfs/module/external/kc/businessobject/Award.java
+++ b/work/src/org/kuali/kfs/module/external/kc/businessobject/Award.java
@@ -79,7 +79,6 @@ public class Award implements ContractsAndGrantsBillingAward {
     private String awardStatusCode;
     private String letterOfCreditFundCode;
     private String grantDescriptionCode;
-    private String letterOfCreditCreationType;
     private String federalPassThroughAgencyNumber;
     private String agencyAnalystName;
     private String analystTelephoneNumber;
@@ -484,15 +483,6 @@ public class Award implements ContractsAndGrantsBillingAward {
 
     public void setGrantDescriptionCode(String grantDescriptionCode) {
         this.grantDescriptionCode = grantDescriptionCode;
-    }
-
-    @Override
-    public String getLetterOfCreditCreationType() {
-        return letterOfCreditCreationType;
-    }
-
-    public void setLetterOfCreditCreationType(String letterOfCreditCreationType) {
-        this.letterOfCreditCreationType = letterOfCreditCreationType;
     }
 
     @Override

--- a/work/src/org/kuali/kfs/module/external/kc/businessobject/AwardAccount.java
+++ b/work/src/org/kuali/kfs/module/external/kc/businessobject/AwardAccount.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,7 +28,6 @@ import org.kuali.kfs.integration.cg.ContractsAndGrantsBillingAwardAccount;
 import org.kuali.kfs.module.external.kc.dto.AwardAccountDTO;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.core.api.mo.common.active.MutableInactivatable;
-import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.kim.api.identity.PersonService;
 import org.kuali.rice.krad.util.ObjectUtils;
@@ -50,8 +49,6 @@ public class AwardAccount implements ContractsAndGrantsBillingAwardAccount, Muta
     private boolean finalBilledIndicator;
     private Date currentLastBilledDate;
     private Date previousLastBilledDate;
-    private KualiDecimal amountToDraw = KualiDecimal.ZERO;// Amount to Draw when awards are pulled up for review.
-    private boolean letterOfCreditReviewIndicator;// The indicator set if the award account amountToDraw is modified by the user.
 
     private Account account;
     private Chart chartOfAccounts;
@@ -126,8 +123,6 @@ public class AwardAccount implements ContractsAndGrantsBillingAwardAccount, Muta
         previousLastBilledDate = (!ObjectUtils.isNull(awardAccountDTO.getPreviousLastBilledDate())) ?
                 new Date(awardAccountDTO.getPreviousLastBilledDate().getTime())
                 : null;
-        amountToDraw = awardAccountDTO.getAmountToDraw();
-        letterOfCreditReviewIndicator = awardAccountDTO.isLetterOfCreditReviewIndicator();
     }
 
     /**
@@ -353,15 +348,5 @@ public class AwardAccount implements ContractsAndGrantsBillingAwardAccount, Muta
     @Override
     public boolean isFinalBilledIndicator() {
         return finalBilledIndicator;
-    }
-
-    @Override
-    public KualiDecimal getAmountToDraw() {
-        return amountToDraw;
-    }
-
-    @Override
-    public boolean isLetterOfCreditReviewIndicator() {
-        return letterOfCreditReviewIndicator;
     }
 }

--- a/work/src/org/kuali/kfs/module/external/kc/service/impl/ContractsAndGrantsModuleBillingServiceImpl.java
+++ b/work/src/org/kuali/kfs/module/external/kc/service/impl/ContractsAndGrantsModuleBillingServiceImpl.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -37,7 +37,6 @@ import org.kuali.kfs.module.external.kc.webService.AwardWebSoapService;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kra.external.award.AwardWebService;
 import org.kuali.rice.core.api.resourceloader.GlobalResourceLoader;
-import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.krad.util.ObjectUtils;
 
 /**
@@ -112,39 +111,11 @@ public class ContractsAndGrantsModuleBillingServiceImpl implements ContractsAndG
     }
 
     @Override
-    public void setLOCCreationTypeToAward(Long proposalNumber, String locCreationType) {
-        AwardBillingUpdateDto updateDto = new AwardBillingUpdateDto();
-        updateDto.setDoLocCreationTypeUpdate(true);
-        updateDto.setLocCreationType(locCreationType);
-        AwardFieldValuesDto searchDto = new AwardFieldValuesDto();
-        searchDto.setAwardId(proposalNumber);
-        handleBillingStatusResult(getAwardWebService().updateAwardBillingStatus(searchDto, updateDto));
-
-    }
-
-    @Override
-    public void setLOCReviewIndicatorToAwardAccount(Map<String, Object> criteria, boolean locReviewIndicator) {
-        AwardBillingUpdateDto updateDto = new AwardBillingUpdateDto();
-        updateDto.setDoLocReviewUpdate(true);
-        updateDto.setLocReviewIndicator(locReviewIndicator);
-        handleBillingStatusResult(getAwardWebService().updateAwardBillingStatus(buildSearchDto(criteria), updateDto));
-    }
-
-    @Override
     public void setFinalBilledToAwardAccount(Map<String, Object> criteria, boolean finalBilled) {
         AwardBillingUpdateDto updateDto = new AwardBillingUpdateDto();
         updateDto.setDoFinalBilledUpdate(true);
         updateDto.setFinalBilledIndicator(finalBilled);
         handleBillingStatusResult(getAwardWebService().updateAwardBillingStatus(buildSearchDto(criteria), updateDto));
-    }
-
-    @Override
-    public void setAmountToDrawToAwardAccount(Map<String, Object> criteria, KualiDecimal amountToDraw) {
-        AwardBillingUpdateDto updateDto = new AwardBillingUpdateDto();
-        updateDto.setDoAmountToDrawUpdate(true);
-        updateDto.setAmountToDraw(amountToDraw);
-        handleBillingStatusResult(getAwardWebService().updateAwardBillingStatus(buildSearchDto(criteria), updateDto));
-
     }
 
     public AwardWebService getAwardWebService() {


### PR DESCRIPTION
Remove loc review indicator and amount to draw from award account and loc creation type from award, as we are no longer using those fields to generate CINVs