### PR TITLE
KFSTP-1858

### DIFF
--- a/work/src/org/kuali/kfs/module/ar/document/PaymentApplicationDocument.java
+++ b/work/src/org/kuali/kfs/module/ar/document/PaymentApplicationDocument.java
@@ -1,18 +1,18 @@
 /*
  * The Kuali Financial System, a comprehensive financial management system for higher education.
- * 
+ *
  * Copyright 2005-2014 The Kuali Foundation
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -887,7 +887,7 @@ public class PaymentApplicationDocument extends GeneralLedgerPostingDocumentBase
             actualDebitEntry.setFinancialBalanceTypeCode(KFSConstants.BALANCE_TYPE_ACTUAL);
             actualDebitEntry.setFinancialDocumentTypeCode(paymentApplicationDocumentTypeCode);
             actualDebitEntry.setTransactionLedgerEntrySequenceNumber(sequenceHelper.getSequenceCounter());
-            actualDebitEntry.setTransactionLedgerEntryDescription(ipa.getDocumentHeader().getDocumentDescription());
+            actualDebitEntry.setTransactionLedgerEntryDescription(getDocumentHeader().getDocumentDescription());
             generatedEntries.add(actualDebitEntry);
             sequenceHelper.increment();
 
@@ -938,7 +938,7 @@ public class PaymentApplicationDocument extends GeneralLedgerPostingDocumentBase
                 offsetDebitEntry.setProjectCode(ipa.getInvoiceDetail().getProjectCode());
             }
             offsetDebitEntry.setTransactionLedgerEntrySequenceNumber(sequenceHelper.getSequenceCounter());
-            offsetDebitEntry.setTransactionLedgerEntryDescription(ipa.getDocumentHeader().getDocumentDescription());
+            offsetDebitEntry.setTransactionLedgerEntryDescription(getDocumentHeader().getDocumentDescription());
             generatedEntries.add(offsetDebitEntry);
             sequenceHelper.increment();
 


### PR DESCRIPTION
invoice paid applieds have not been saved to the db during initial glpe generation; therefore, they can't use OJB to pull back a document header...and since we're on their document, it seems strange to do so in any case