### PR TITLE
KFSTP-1951

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,12 @@
                     <groupId>org.apache.tomcat.maven</groupId>
                     <artifactId>tomcat7-maven-plugin</artifactId>
                     <version>${plugin.tomcat.version}</version>
+                    <configuration>
+                        <path>/${project.artifactId}-dev</path>
+                        <systemProperties>
+                            <org.apache.el.parser.SKIP_IDENTIFIER_CHECK>true</org.apache.el.parser.SKIP_IDENTIFIER_CHECK>
+                        </systemProperties>
+                    </configuration>
                     <dependencies>
                         <dependency>
                             <groupId>mysql</groupId>

--- a/src/main/java/org/kuali/kfs/module/purap/document/service/impl/PaymentRequestServiceImpl.java
+++ b/src/main/java/org/kuali/kfs/module/purap/document/service/impl/PaymentRequestServiceImpl.java
@@ -395,7 +395,8 @@ public class PaymentRequestServiceImpl implements PaymentRequestService {
         // Iterate all source accounting lines on the document, deriving a
         // minimum limit from each according to chart, chart and account, and
         // chart and organization.
-        for (SourceAccountingLine line : purapAccountingService.generateSummary(document.getItems())) {
+        final List<SourceAccountingLine> summaryLines = purapAccountingService.generateSummary(document.getItems());
+        for (SourceAccountingLine line : summaryLines) {
             // check to make sure the account is in the auto approve exclusion list
             Map<String, Object> autoApproveMap = new HashMap<String, Object>();
             autoApproveMap.put("chartOfAccountsCode", line.getChartOfAccountsCode());


### PR DESCRIPTION
Have Tomcat deploy to the right path and have it skip the identifier check; also fixes to a class so that maven's compiler stops whining about it quite so often...