### PR TITLE
KFSTI-1780

### DIFF
--- a/src/main/java/org/kuali/kfs/sys/context/PropertyLoadingFactoryBean.java
+++ b/src/main/java/org/kuali/kfs/sys/context/PropertyLoadingFactoryBean.java
@@ -59,9 +59,9 @@ public class PropertyLoadingFactoryBean implements FactoryBean<Properties> {
             loadPropertyList(props,SECURITY_PROPERTY_FILE_NAME_KEY);
         } else {
             loadPropertyList(props,PROPERTY_FILE_NAMES_KEY);
-            if (testMode) {
-                loadPropertyList(props,PROPERTY_TEST_FILE_NAMES_KEY);
-            }            
+        }
+        if (testMode) {
+            loadPropertyList(props,PROPERTY_TEST_FILE_NAMES_KEY);
         }
         if (StringUtils.isBlank(System.getProperty(HTTP_URL_PROPERTY_NAME))) {
             props.put(KSB_REMOTING_URL_PROPERTY_NAME, props.getProperty(KFSConstants.APPLICATION_URL_KEY) + REMOTING_URL_SUFFIX);

--- a/src/test/resources/kfs-startup-test.xml
+++ b/src/test/resources/kfs-startup-test.xml
@@ -23,6 +23,10 @@
                            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<import resource="classpath:kfs-startup.xml" />
+
+    <bean id="properties" class="org.kuali.kfs.sys.context.PropertyLoadingFactoryBean" p:testMode="true"/>
+
+    <bean id="securityProperties" class="org.kuali.kfs.sys.context.PropertyLoadingFactoryBean" p:secureMode="true" p:testMode="true"/>
 	
 	<!--  replace the kfsConfigurer bean with one which runs in test mode -->
 	<bean name="kfsConfigurer" class="org.kuali.kfs.sys.context.KFSConfigurer" lazy-init="false"


### PR DESCRIPTION
Fix TEM unit tests.  Mostly, this means that we need to load the test properties if we're running unit tests.  We discovered that PropertyLoadingFactoryBean is acting a wee bit crazy.....